### PR TITLE
Replace `...` syntax with `pass` for python2 compatibility

### DIFF
--- a/manly.py
+++ b/manly.py
@@ -93,7 +93,7 @@ def parse_manpage(page, flags):
         try:
             segments.append(section_top[1].strip())
         except IndexError:
-            ...
+            pass
 
         for flag in flags:
             for segment in segments:


### PR DESCRIPTION
Very cool project!

I'm not sure what the purpose of the `...` syntax was, it doesn't seem to have any functional effect, and causes a `SyntaxError` in python2 :

```
me@mybox:/mnt/c/Users/Spencatro/manly$ python manly.py tail -f
  File "manly.py", line 96
    ...
    ^
SyntaxError: invalid syntax
```

With this 1-liner, I now get:

```
me@mybox:/mnt/c/Users/Spencatro/manly$ python manly.py tail -f

tail - output the last part of files
====================================

      -f, --follow[={name|descriptor}]
              output appended data as the file grows;

me@mybox:/mnt/c/Users/Spencatro/manly$ python manly.py notify-send -it
No manual entry for notify-send
```