### PR TITLE
Issue #14: Print error to stderr when man exits with non-zero status …

### DIFF
--- a/manly.py
+++ b/manly.py
@@ -112,7 +112,7 @@ def main(command):
     if process.returncode == 0:
         manpage = out.decode('utf-8')
     else:
-        print(err.decode('utf-8'))
+        print(err.decode('utf-8'), file=sys.stderr)
         sys.exit(process.returncode)
 
     # commands such as `clang` use single dash names like "-nostdinc"


### PR DESCRIPTION
Changed `check_output` with `Popen`. 
Surrounding `try...catch` does not needed anymore.
Exit with not hardcoded `16` exit code, but with code that subprocess returned.
Also there was parentheses, but Popen create a new subprocess, so `()` in shell command was removed.

Will appreciate your feedback on this PR :bear: