### PR TITLE
Improved Single-Dash Flag Parsing

### DIFF
--- a/manly.py
+++ b/manly.py
@@ -55,7 +55,7 @@ VERSION = (
 def parse_flags(raw_flags):
     """Return a list of flags.
 
-    If *single_dash* is False, concatenated flags will be split into
+    Concatenated flags will be split into
     individual flags (eg. '-la' -> '-l', '-a').
     """
     flags = []

--- a/manly.py
+++ b/manly.py
@@ -52,7 +52,7 @@ VERSION = (
 ) % (__version__, __author__, __author__)
 
 
-def parse_flags(raw_flags, single_dash=False):
+def parse_flags(raw_flags):
     """Return a list of flags.
 
     If *single_dash* is False, concatenated flags will be split into
@@ -60,9 +60,11 @@ def parse_flags(raw_flags, single_dash=False):
     """
     flags = []
     for flag in raw_flags:
-        if flag.startswith("--") or single_dash:
+        if flag.startswith("--"):
             flags.append(flag)
         elif flag.startswith("-"):
+            if len(flag) > 2:
+                flags.append(flag)
             for char in flag[1:]:
                 flags.append("-" + char)
     return flags
@@ -119,7 +121,7 @@ def main(command):
 
     # commands such as `clang` use single dash names like "-nostdinc"
     uses_single_dash_names = bool(re.search(r"\n\n\s+-\w{2,}", manpage))
-    flags = parse_flags(flags, single_dash=uses_single_dash_names)
+    flags = parse_flags(flags)
     output = parse_manpage(manpage, flags)
     title = _ANSI_BOLD % (
         re.search(r"(?<=^NAME\n\s{5}).+", manpage, re.MULTILINE).group(0).strip()


### PR DESCRIPTION
The ```parse_flags()``` function no longer accepts a ```single_dash``` argument. The if ... elif statment in parse_flags does not distinguish concatenated single-char flag arguments from long arguments. For example, it interprets the concatenated flags in ```curl -sS``` as a single-dash long argument. This causes it to skip the individual character parsing done in the elif. 

The single_dash has been replaced by just adding the whole argument as one of the flags in in the ```flags``` array. Using the same example, it would add "-sS" as one of the flags in addition to the parsed "-s" and "-S". This way, if "-sS" is a long flag, it would be parsed from the manpage. If so, the "-s" and "-S" flags would not be output since commands can't mix single-char and long flags.