### PR TITLE
Add a quick check for man not being in the path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 
 # Editor config
 .vscode
+
+# Pycharm config
+.idea

--- a/manly.py
+++ b/manly.py
@@ -112,10 +112,14 @@ def manly(command):
         shell=True,
     )
     out, err = process.communicate()
+
     if process.returncode == 0:
         manpage = out.decode("utf-8")
     else:
-        print(err.decode("utf-8"), file=sys.stderr)
+        if "not found" in err.decode("utf-8"):
+            print("man not found in your path. Please install it or add it to your path", file=sys.stderr)
+        else:
+            print(err.decode("utf-8"), file=sys.stderr)
         sys.exit(process.returncode)
 
     # commands such as `clang` use single dash names like "-nostdinc"

--- a/manly.py
+++ b/manly.py
@@ -116,10 +116,13 @@ def manly(command):
     if process.returncode == 0:
         manpage = out.decode("utf-8")
     else:
-        if "not found" in err.decode("utf-8"):
-            print("man not found in your path. Please install it or add it to your path", file=sys.stderr)
+        if process.returncode == 126:
+            error_msg = "Error: 'man' is not executable."
+        elif process.returncode == 127:
+            error_msg = "Error: 'man' not found in your path. Please install it or add it to your path.2w"
         else:
-            print(err.decode("utf-8"), file=sys.stderr)
+            error_msg = err.decode("utf-8")
+        print(error_msg, file=sys.stdout)
         sys.exit(process.returncode)
 
     # commands such as `clang` use single dash names like "-nostdinc"


### PR DESCRIPTION
https://github.com/carlbordum/manly/issues/19

This looks for "not found" in the stderr from running man and prints a custom error message relating to man either not being installed or not being in the path.

Tested this out using docker - python:3.6.6-slim
```
root@54db869e79c4:/manly# man
bash: man: command not found
root@54db869e79c4:/manly# python manly.py man
man not found in your path. Please install it or add it to your path
```